### PR TITLE
Modifying selector, for better compatibility with more pages at Wikipedia

### DIFF
--- a/js/jquery.wikiblurb.js
+++ b/js/jquery.wikiblurb.js
@@ -120,7 +120,7 @@
 				    break;
 				
 				case 'infobox':
-				    object.html($(blurb).find('.vcard'));
+				    object.html($(blurb).find('.infobox'));
 				    break;
 				    
 				case 'custom':


### PR DESCRIPTION
Using the selector `.vcard` doesn't work for all pages at Wikipedia. Switching to the selector `.infobox` instead.

Refs. https://github.com/9bitStudios/wikiblurb/issues/3